### PR TITLE
Excerpt como shortcode

### DIFF
--- a/_includes/_tutoriales-lista.html
+++ b/_includes/_tutoriales-lista.html
@@ -14,6 +14,6 @@
     </div> <!-- .tutoriales-lista-tutorial__meta -->
 
     <div class="tutoriales-lista-tutorial__excerpt">
-        {{ tutorial | excerpt }}
+        {{ excerpt tutorial }}
     </div>  <!-- .tutoriales-lista-tutorial__contenido -->
 </li>


### PR DESCRIPTION
Antes excerpt era un filtro y se cambió a un shortcode