### PR TITLE
README.md h1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# manualvarado
+# manualvarado.me
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/2fdd0363-ed91-4b4f-a46d-5891a629ddb1/deploy-status)](https://app.netlify.com/sites/manualvarado/deploys)
 


### PR DESCRIPTION
Cambié el título del README de manualvarado a manualvarado.me por mi nuevo dominio.