### PR TITLE
Coma antes de "leer 📖"

### DIFF
--- a/index.liquid
+++ b/index.liquid
@@ -19,7 +19,7 @@ pagination:
 			Me dedico al desarrollo web, especialmente con WordPress.
 		</p>
 		<p class="hero__paragraph">
-			Además de programar, me gustan los idiomas 🎌, la música 🎸, el anime 👹🍙, los videojuegos 🎮, las películas 📽🍿, hacer ejercicio 🏃‍♂️, salir a caminar 🚶‍♂️ leer 📖 y algunas cosas más 🐈✨.
+			Además de programar, me gustan los idiomas 🎌, la música 🎸, el anime 👹🍙, los videojuegos 🎮, las películas 📽🍿, hacer ejercicio 🏃‍♂️, salir a caminar 🚶‍♂️, leer 📖 y algunas cosas más 🐈✨.
 		</p>
 	</div> <!-- .hero__content -->
 </section> <!-- .hero -->


### PR DESCRIPTION
En el header en la lista de cosas que me gusta hacer, no había coma después de "salir a caminar 🚶‍♂️".